### PR TITLE
Rewrite all user-facing strings in ASD-STE100

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,20 +54,29 @@ If a `.env` from the old build is found next to the executable (or in `/etc/phot
 3. Configure the A7IV's "Auto FTP" with these credentials. Photos taken on that body are attributed to that photographer in the DB and (optionally) on the slideshow overlay.
 4. Recommended: in the camera's "Setting the image size to be transferred for JPEG/HEIF images" menu, pick **Small** for sub-second upload latency. The server still generates display + thumb renditions; a 2 MP source is plenty for 1080p audience screens.
 
-## Curation modes
+## Selection modes
 
-Per event, set one of:
+Per event, set one of (the **Selection mode** field in the *New event* dialog):
 
 - `auto` — every ingested image enters the slideshow.
-- `auto-skip-blurry` — images with `sharpness_score` below a threshold are auto-excluded; one-click re-include from the queue.
-- `approval` — every image lands in a pending tray; operator approves before the audience sees it.
+- `auto-skip-blurry` — images with `sharpness_score` below the **Sharpness limit** are auto-excluded; one-click re-include from the queue.
+- `approval` — every image lands in the **To approve** tab of the queue; the operator approves it before the audience sees it.
 
 ## OBS integration
 
 Two ways:
 
-- **Browser source** (always works): point OBS at `http://<your-machine>:3001/slideshow/?token=<your-token>`. Token is in the desktop app under Settings → Authentication. Use `Settings → Network → Bind host = 0.0.0.0` for LAN access from another OBS box.
+- **Browser source** (always works): point OBS at `http://<your-machine>:3001/slideshow/?token=<your-token>`. Token is in the desktop app under Settings → Display token. Use `Settings → Network → Bind host = 0.0.0.0` for LAN access from another OBS box.
 - **WebSocket** (optional): set `OBS WebSocket URL` and `Password` in Settings → OBS WebSocket. The server can then drive scene switches; reload the OBS connection live without a server restart.
+
+## Writing strings
+
+Every operator- and audience-facing string in this repo is written in **ASD-STE100**
+(Simplified Technical English). A French translation, when it happens, follows
+**le Français Rationalisé du GIFAS**. The rules, the glossary, and what is out of
+scope (enum values, camera menu paths, code comments) are in
+[`docs/string-style-guide.md`](docs/string-style-guide.md). Read it before you add
+a label, a hint, or an error message.
 
 ## Workspace layout
 

--- a/apps/desktop/src/bootstrap/dataDir.ts
+++ b/apps/desktop/src/bootstrap/dataDir.ts
@@ -22,7 +22,7 @@ export type ResolvedDataDir = {
 export function resolveDataDir(override?: string | null): ResolvedDataDir {
   if (override) {
     if (!tryWritable(override)) {
-      throw new Error(`data directory is not writable: ${override}`);
+      throw new Error(`the data directory does not have write access: ${override}`);
     }
     return { dir: override, source: 'override' };
   }

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -84,7 +84,7 @@ async function bootApp(): Promise<void> {
     bootlog('resolveDataDir failed', { err: (err as Error).message });
     dialog.showErrorBox(
       'Photolive',
-      `Failed to locate a writable data directory.\n\n${(err as Error).message}`,
+      `The app could not find a data directory with write access.\n\n${(err as Error).message}`,
     );
     app.exit(1);
     return;
@@ -100,7 +100,10 @@ async function bootApp(): Promise<void> {
     });
   } catch (err) {
     bootlog('loadOrInitSettings failed', { err: (err as Error).message });
-    dialog.showErrorBox('Photolive', `Failed to load settings.json.\n\n${(err as Error).message}`);
+    dialog.showErrorBox(
+      'Photolive',
+      `The app could not read settings.json.\n\n${(err as Error).message}`,
+    );
     app.exit(1);
     return;
   }
@@ -110,9 +113,9 @@ async function bootApp(): Promise<void> {
     setImmediate(() => {
       dialog.showMessageBox({
         type: 'info',
-        title: 'Photolive — settings imported',
-        message: 'Imported existing photolive configuration',
-        detail: `Read your previous .env at ${settings.migratedFromEnv} and folded its values into ${settings.path}. You can edit them in Settings.`,
+        title: 'Photolive — the app read your settings',
+        message: 'The app read your existing Photolive configuration',
+        detail: `The app read your previous .env file at ${settings.migratedFromEnv}. It wrote the values into ${settings.path}. You can change them in Settings.`,
       });
     });
   }
@@ -125,7 +128,7 @@ async function bootApp(): Promise<void> {
     bootlog('loadServer failed', { err: (err as Error).message, stack: (err as Error).stack });
     dialog.showErrorBox(
       'Photolive',
-      `Failed to load the photolive server module.\n\n${(err as Error).message}`,
+      `The app could not load the Photolive server module.\n\n${(err as Error).message}`,
     );
     app.exit(1);
     return;
@@ -158,7 +161,7 @@ async function bootApp(): Promise<void> {
     bootlog('startServer failed', { err: (err as Error).message, stack: (err as Error).stack });
     dialog.showErrorBox(
       'Photolive',
-      `Failed to start the photolive server.\n\n${(err as Error).message}`,
+      `The app could not start the Photolive server.\n\n${(err as Error).message}`,
     );
     app.exit(1);
     return;
@@ -257,6 +260,9 @@ app.on('web-contents-created', (_event, contents) => {
 });
 
 bootApp().catch((err) => {
-  dialog.showErrorBox('Photolive', `Fatal startup error.\n\n${(err as Error).message ?? err}`);
+  dialog.showErrorBox(
+    'Photolive',
+    `The app stopped during the start.\n\n${(err as Error).message ?? err}`,
+  );
   app.exit(1);
 });

--- a/apps/server/src/app.ts
+++ b/apps/server/src/app.ts
@@ -73,10 +73,10 @@ export async function buildApp(): Promise<FastifyInstance> {
     if (isPublicAuthRoute(request)) return;
     const ctx = authenticate(request);
     if (!ctx) {
-      return reply.code(401).send({ error: 'unauthorized' });
+      return reply.code(401).send({ error: 'you must log in first' });
     }
     if (!('operator' in ctx) && !isDisplayAllowed(request.method, request.url)) {
-      return reply.code(403).send({ error: 'forbidden' });
+      return reply.code(403).send({ error: 'you do not have permission for this operation' });
     }
     request.authCtx = ctx;
   });
@@ -217,17 +217,20 @@ export async function startServer(opts: StartServerOptions): Promise<StartedServ
     const oldConfig = config;
     const reasons: string[] = [];
 
-    if (oldConfig.port !== newConfig.port) reasons.push('Network port changed');
-    if (oldConfig.host !== newConfig.host) reasons.push('Network host changed');
-    if (oldConfig.databasePath !== newConfig.databasePath) reasons.push('Database path changed');
+    if (oldConfig.port !== newConfig.port) reasons.push('You changed the network port.');
+    if (oldConfig.host !== newConfig.host) reasons.push('You changed the network host.');
+    if (oldConfig.databasePath !== newConfig.databasePath)
+      reasons.push('You changed the database path.');
     if (!arraysEqual(oldConfig.allowedOrigins, newConfig.allowedOrigins)) {
-      reasons.push('Allowed origins changed (CORS)');
+      reasons.push('You changed the allowed CORS origins.');
     }
     if (oldConfig.photosRoot !== newConfig.photosRoot) {
-      reasons.push('Photos root changed (existing events keep their stored photosDir)');
+      reasons.push('You changed the photos root. The existing events keep their photo directory.');
     }
     if (oldConfig.renditionsRoot !== newConfig.renditionsRoot) {
-      reasons.push('Renditions root changed (existing renditions stay at the old path)');
+      reasons.push(
+        'You changed the renditions root. The existing renditions stay at the old path.',
+      );
     }
 
     // Hot-reloadable: install the new config, then poke each subsystem.

--- a/apps/server/src/config.ts
+++ b/apps/server/src/config.ts
@@ -194,7 +194,7 @@ export function setConfig(next: Config): void {
 export function getConfig(): Config {
   if (!current) {
     throw new Error(
-      'config has not been initialized — call setConfig(buildConfigFromEnv(...)) or setConfig(buildConfigFromFile(...)) before importing services',
+      'the configuration is not initialized. Call setConfig(buildConfigFromEnv(...)) or setConfig(buildConfigFromFile(...)) before you import the services.',
     );
   }
   return current;

--- a/apps/server/src/main.ts
+++ b/apps/server/src/main.ts
@@ -34,7 +34,7 @@ function bootstrap(): Bootstrap {
   if (settingsPath) {
     const abs = resolve(settingsPath);
     if (!existsSync(abs)) {
-      console.error(`settings file not found: ${abs}`);
+      console.error(`the server could not find the settings file: ${abs}`);
       process.exit(1);
     }
     const raw = JSON.parse(readFileSync(abs, 'utf8'));
@@ -75,7 +75,7 @@ async function main(): Promise<void> {
   const server = await startServer(boot);
 
   const shutdown = async (signal: string): Promise<void> => {
-    console.log(`received ${signal}, shutting down`);
+    console.log(`the server received ${signal}. The server stops.`);
     await server.shutdown();
     process.exit(0);
   };
@@ -84,6 +84,6 @@ async function main(): Promise<void> {
 }
 
 main().catch((err) => {
-  console.error('fatal startup error', err);
+  console.error('the server stopped during the start', err);
   process.exit(1);
 });

--- a/apps/server/src/routes/appSettings.ts
+++ b/apps/server/src/routes/appSettings.ts
@@ -24,8 +24,8 @@ export async function appSettingsRoutes(app: FastifyInstance): Promise<void> {
   app.put('/api/app-settings', async (req, reply) => {
     if (!settingsStore.canMutate()) {
       return reply.code(409).send({
-        error: 'settings are not mutable in this mode',
-        hint: 'server bootstrapped from .env; edit .env and restart, or pass --settings <path>',
+        error: 'you cannot change the settings in this mode',
+        hint: 'the server started from a .env file. Change the .env file and start the server again, or use --settings <path>.',
       });
     }
 
@@ -60,14 +60,14 @@ export async function appSettingsRoutes(app: FastifyInstance): Promise<void> {
 
   app.post('/api/app-settings/rotate-token', async (_req, reply) => {
     if (!settingsStore.canMutate()) {
-      return reply.code(409).send({ error: 'settings are not mutable in this mode' });
+      return reply.code(409).send({ error: 'you cannot change the settings in this mode' });
     }
     const newToken = randomBytes(32).toString('base64url');
     const next = settingsStore.rotateToken(newToken);
     const reload = await serverLifecycle.reload(
       buildConfigFromFile(next, settingsStore.getDataDir()),
     );
-    logger.warn('auth token rotated; existing sessions will be invalidated');
+    logger.warn('display token replaced');
     return {
       settings: redact(next, false),
       newToken,

--- a/apps/server/src/routes/auth.ts
+++ b/apps/server/src/routes/auth.ts
@@ -42,7 +42,7 @@ export async function authRoutes(app: FastifyInstance): Promise<void> {
     const parsed = setupSchema.safeParse(request.body);
     if (!parsed.success) return reply.code(400).send({ error: parsed.error.flatten() });
     if (userService.count() > 0) {
-      return reply.code(409).send({ error: 'setup already completed' });
+      return reply.code(409).send({ error: 'the setup is already complete' });
     }
     const user = userService.create({
       username: parsed.data.username,
@@ -59,7 +59,8 @@ export async function authRoutes(app: FastifyInstance): Promise<void> {
     const parsed = loginSchema.safeParse(request.body);
     if (!parsed.success) return reply.code(400).send({ error: parsed.error.flatten() });
     const user = userService.verify(parsed.data.username, parsed.data.password);
-    if (!user) return reply.code(401).send({ error: 'invalid credentials' });
+    if (!user)
+      return reply.code(401).send({ error: 'the user name or the password is not correct' });
     const session = sessionService.create(user.id);
     setSessionCookie(request, reply, session.id);
     return { user };
@@ -70,7 +71,7 @@ export async function authRoutes(app: FastifyInstance): Promise<void> {
   app.post('/api/auth/bootstrap', async (request, reply) => {
     const secret = (request.body as { secret?: unknown } | undefined)?.secret;
     if (typeof secret !== 'string' || !authRuntime.isValidLocalSecret(secret)) {
-      return reply.code(403).send({ error: 'invalid bootstrap secret' });
+      return reply.code(403).send({ error: 'the bootstrap secret is not correct' });
     }
     if (userService.count() === 0) {
       // Fresh install: renderer should show the create-admin wizard, then call
@@ -78,7 +79,7 @@ export async function authRoutes(app: FastifyInstance): Promise<void> {
       return { setupRequired: true, user: null };
     }
     const user = userService.getOwner();
-    if (!user) return reply.code(500).send({ error: 'no owner account' });
+    if (!user) return reply.code(500).send({ error: 'there is no owner account' });
     const session = sessionService.create(user.id);
     setSessionCookie(request, reply, session.id);
     return { setupRequired: false, user };
@@ -92,7 +93,8 @@ export async function authRoutes(app: FastifyInstance): Promise<void> {
 
   app.get('/api/auth/me', async (request, reply) => {
     const ctx = request.authCtx;
-    if (!ctx || !('operator' in ctx)) return reply.code(401).send({ error: 'unauthorized' });
+    if (!ctx || !('operator' in ctx))
+      return reply.code(401).send({ error: 'you must log in first' });
     return { user: ctx.operator };
   });
 }

--- a/apps/server/src/routes/events.ts
+++ b/apps/server/src/routes/events.ts
@@ -16,14 +16,16 @@ import { wsService } from '../services/wsService.js';
 function replyEventWriteError(reply: FastifyReply, err: unknown): FastifyReply {
   const msg = err instanceof Error ? err.message : String(err);
   if (/UNIQUE constraint failed: events\.slug/i.test(msg)) {
-    return reply.code(409).send({ error: 'an event with this slug already exists' });
+    return reply.code(409).send({ error: 'this slug is already in use by a different event' });
   }
   const code = (err as NodeJS.ErrnoException)?.code;
   if (code && ['EACCES', 'EPERM', 'EROFS', 'ENOENT', 'ENOTDIR'].includes(code)) {
-    return reply.code(400).send({ error: `cannot create photos directory (${code}): ${msg}` });
+    return reply.code(400).send({
+      error: `the server could not make the photo directory (${code}): ${msg}`,
+    });
   }
   logger.error({ err }, 'event write failed');
-  return reply.code(500).send({ error: 'failed to save event' });
+  return reply.code(500).send({ error: 'the server could not save the event' });
 }
 
 export async function eventRoutes(app: FastifyInstance): Promise<void> {
@@ -33,7 +35,7 @@ export async function eventRoutes(app: FastifyInstance): Promise<void> {
 
   app.get<{ Params: { id: string } }>('/api/events/:id', async (req, reply) => {
     const event = eventService.get(req.params.id);
-    if (!event) return reply.code(404).send({ error: 'not found' });
+    if (!event) return reply.code(404).send({ error: 'the server could not find the event' });
     return { event };
   });
 
@@ -62,14 +64,14 @@ export async function eventRoutes(app: FastifyInstance): Promise<void> {
     } catch (err) {
       return replyEventWriteError(reply, err);
     }
-    if (!event) return reply.code(404).send({ error: 'not found' });
+    if (!event) return reply.code(404).send({ error: 'the server could not find the event' });
     wsService.broadcast('event.updated', { event });
     return { event };
   });
 
   app.post<{ Params: { id: string } }>('/api/events/:id/activate', async (req, reply) => {
     const event = eventService.setActive(req.params.id);
-    if (!event) return reply.code(404).send({ error: 'not found' });
+    if (!event) return reply.code(404).send({ error: 'the server could not find the event' });
     await fileWatcherService.watchActiveEvent();
     slideshowService.reload();
     wsService.broadcast('event.activated', { event });
@@ -78,20 +80,20 @@ export async function eventRoutes(app: FastifyInstance): Promise<void> {
 
   app.post<{ Params: { id: string } }>('/api/events/:id/archive', async (req, reply) => {
     const event = eventService.archive(req.params.id);
-    if (!event) return reply.code(404).send({ error: 'not found' });
+    if (!event) return reply.code(404).send({ error: 'the server could not find the event' });
     return { event };
   });
 
   app.post<{ Params: { id: string } }>('/api/events/:id/unarchive', async (req, reply) => {
     const event = eventService.unarchive(req.params.id);
-    if (!event) return reply.code(404).send({ error: 'not found' });
+    if (!event) return reply.code(404).send({ error: 'the server could not find the event' });
     return { event };
   });
 
   app.delete<{ Params: { id: string } }>('/api/events/:id', async (req, reply) => {
     const wasActive = eventService.get(req.params.id)?.isActive ?? false;
     const ok = eventService.delete(req.params.id);
-    if (!ok) return reply.code(404).send({ error: 'not found' });
+    if (!ok) return reply.code(404).send({ error: 'the server could not find the event' });
     // If we just deleted the active event, the watcher and slideshow need to drop their state.
     if (wasActive) {
       await fileWatcherService.watchActiveEvent();

--- a/apps/server/src/routes/frontends.ts
+++ b/apps/server/src/routes/frontends.ts
@@ -52,10 +52,12 @@ export async function frontendRoutes(app: FastifyInstance): Promise<void> {
       wildcard: false,
     });
     app.setNotFoundHandler(async (request, reply) => {
-      if (request.url.startsWith('/api/')) return reply.code(404).send({ error: 'not found' });
-      if (request.url.startsWith('/ws')) return reply.code(404).send({ error: 'not found' });
+      if (request.url.startsWith('/api/'))
+        return reply.code(404).send({ error: 'the server could not find this resource' });
+      if (request.url.startsWith('/ws'))
+        return reply.code(404).send({ error: 'the server could not find this resource' });
       if (request.url.startsWith('/renditions/'))
-        return reply.code(404).send({ error: 'not found' });
+        return reply.code(404).send({ error: 'the server could not find this resource' });
       // Browser auto-requests these; we don't ship them. 204 keeps the console clean.
       if (request.url === '/favicon.ico' || request.url === '/robots.txt') {
         return reply.code(204).send();
@@ -66,7 +68,8 @@ export async function frontendRoutes(app: FastifyInstance): Promise<void> {
           ? slideshowDist
           : controlDist;
       const indexPath = resolve(indexDir, 'index.html');
-      if (!existsSync(indexPath)) return reply.code(404).send({ error: 'not found' });
+      if (!existsSync(indexPath))
+        return reply.code(404).send({ error: 'the server could not find this resource' });
       return reply.type('text/html').send(readFileSync(indexPath));
     });
     logger.info({ controlDist }, 'serving web-control bundle at /');

--- a/apps/server/src/routes/images.ts
+++ b/apps/server/src/routes/images.ts
@@ -12,7 +12,7 @@ export async function imageRoutes(app: FastifyInstance): Promise<void> {
     Querystring: { status?: string; limit?: number };
   }>('/api/events/:eventId/images', async (req, reply) => {
     const event = eventService.get(req.params.eventId);
-    if (!event) return reply.code(404).send({ error: 'event not found' });
+    if (!event) return reply.code(404).send({ error: 'the server could not find the event' });
     const status = req.query.status
       ? (req.query.status.split(',').filter(Boolean) as ImageStatus[])
       : undefined;
@@ -29,7 +29,7 @@ export async function imageRoutes(app: FastifyInstance): Promise<void> {
     '/api/events/:eventId/images/pending',
     async (req, reply) => {
       const event = eventService.get(req.params.eventId);
-      if (!event) return reply.code(404).send({ error: 'event not found' });
+      if (!event) return reply.code(404).send({ error: 'the server could not find the event' });
       return { images: imageService.pendingTray(req.params.eventId) };
     },
   );
@@ -38,26 +38,26 @@ export async function imageRoutes(app: FastifyInstance): Promise<void> {
     '/api/events/:eventId/images/queue',
     async (req, reply) => {
       const event = eventService.get(req.params.eventId);
-      if (!event) return reply.code(404).send({ error: 'event not found' });
+      if (!event) return reply.code(404).send({ error: 'the server could not find the event' });
       return { images: imageService.approvedQueue(req.params.eventId) };
     },
   );
 
   app.get<{ Params: { eventId: string } }>('/api/events/:eventId/latency', async (req, reply) => {
     const event = eventService.get(req.params.eventId);
-    if (!event) return reply.code(404).send({ error: 'event not found' });
+    if (!event) return reply.code(404).send({ error: 'the server could not find the event' });
     return { averageMs: imageService.averageIngestLatencyMs(req.params.eventId) };
   });
 
   app.get<{ Params: { id: string } }>('/api/images/:id', async (req, reply) => {
     const image = imageService.get(req.params.id);
-    if (!image) return reply.code(404).send({ error: 'not found' });
+    if (!image) return reply.code(404).send({ error: 'the server could not find the image' });
     return { image };
   });
 
   app.post<{ Params: { id: string } }>('/api/images/:id/approve', async (req, reply) => {
     const image = ingestService.approve(req.params.id);
-    if (!image) return reply.code(404).send({ error: 'not found' });
+    if (!image) return reply.code(404).send({ error: 'the server could not find the image' });
     return { image };
   });
 
@@ -65,7 +65,7 @@ export async function imageRoutes(app: FastifyInstance): Promise<void> {
     '/api/images/:id/reject',
     async (req, reply) => {
       const image = ingestService.reject(req.params.id, req.body?.reason);
-      if (!image) return reply.code(404).send({ error: 'not found' });
+      if (!image) return reply.code(404).send({ error: 'the server could not find the image' });
       return { image };
     },
   );
@@ -74,14 +74,14 @@ export async function imageRoutes(app: FastifyInstance): Promise<void> {
     '/api/images/:id/exclude',
     async (req, reply) => {
       const image = ingestService.exclude(req.params.id, req.body?.reason);
-      if (!image) return reply.code(404).send({ error: 'not found' });
+      if (!image) return reply.code(404).send({ error: 'the server could not find the image' });
       return { image };
     },
   );
 
   app.post<{ Params: { id: string } }>('/api/images/:id/include', async (req, reply) => {
     const image = ingestService.include(req.params.id);
-    if (!image) return reply.code(404).send({ error: 'not found' });
+    if (!image) return reply.code(404).send({ error: 'the server could not find the image' });
     return { image };
   });
 
@@ -89,7 +89,7 @@ export async function imageRoutes(app: FastifyInstance): Promise<void> {
     const parsed = captionSchema.safeParse(req.body);
     if (!parsed.success) return reply.code(400).send({ error: parsed.error.flatten() });
     const image = imageService.setCaption(req.params.id, parsed.data.text);
-    if (!image) return reply.code(404).send({ error: 'not found' });
+    if (!image) return reply.code(404).send({ error: 'the server could not find the image' });
     wsService.broadcast('image.updated', { image });
     return { image };
   });
@@ -98,7 +98,7 @@ export async function imageRoutes(app: FastifyInstance): Promise<void> {
     '/api/events/:eventId/queue',
     async (req, reply) => {
       const event = eventService.get(req.params.eventId);
-      if (!event) return reply.code(404).send({ error: 'event not found' });
+      if (!event) return reply.code(404).send({ error: 'the server could not find the event' });
       if (!Array.isArray(req.body?.imageIds)) {
         return reply.code(400).send({ error: 'imageIds must be an array' });
       }

--- a/apps/server/src/routes/photographers.ts
+++ b/apps/server/src/routes/photographers.ts
@@ -9,7 +9,7 @@ export async function photographerRoutes(app: FastifyInstance): Promise<void> {
     '/api/events/:eventId/photographers',
     async (req, reply) => {
       const event = eventService.get(req.params.eventId);
-      if (!event) return reply.code(404).send({ error: 'event not found' });
+      if (!event) return reply.code(404).send({ error: 'the server could not find the event' });
       return { photographers: photographerService.listForEvent(req.params.eventId) };
     },
   );
@@ -18,7 +18,7 @@ export async function photographerRoutes(app: FastifyInstance): Promise<void> {
     '/api/events/:eventId/photographers',
     async (req, reply) => {
       const event = eventService.get(req.params.eventId);
-      if (!event) return reply.code(404).send({ error: 'event not found' });
+      if (!event) return reply.code(404).send({ error: 'the server could not find the event' });
       const parsed = photographerCreateSchema.safeParse(req.body);
       if (!parsed.success) return reply.code(400).send({ error: parsed.error.flatten() });
       const created = photographerService.create({
@@ -38,7 +38,8 @@ export async function photographerRoutes(app: FastifyInstance): Promise<void> {
     const parsed = photographerUpdateSchema.safeParse(req.body);
     if (!parsed.success) return reply.code(400).send({ error: parsed.error.flatten() });
     const updated = photographerService.update(req.params.id, parsed.data);
-    if (!updated) return reply.code(404).send({ error: 'not found' });
+    if (!updated)
+      return reply.code(404).send({ error: 'the server could not find the photographer' });
     wsService.broadcast('photographer.updated', { photographer: updated });
     return { photographer: updated };
   });
@@ -47,14 +48,15 @@ export async function photographerRoutes(app: FastifyInstance): Promise<void> {
     '/api/photographers/:id/rotate-password',
     async (req, reply) => {
       const result = photographerService.rotatePassword(req.params.id);
-      if (!result) return reply.code(404).send({ error: 'not found' });
+      if (!result)
+        return reply.code(404).send({ error: 'the server could not find the photographer' });
       return { photographer: result };
     },
   );
 
   app.delete<{ Params: { id: string } }>('/api/photographers/:id', async (req, reply) => {
     const ok = photographerService.delete(req.params.id);
-    if (!ok) return reply.code(404).send({ error: 'not found' });
+    if (!ok) return reply.code(404).send({ error: 'the server could not find the photographer' });
     wsService.broadcast('photographer.removed', { photographerId: req.params.id });
     return { ok: true };
   });

--- a/apps/server/src/routes/settings.ts
+++ b/apps/server/src/routes/settings.ts
@@ -7,13 +7,13 @@ import { wsService } from '../services/wsService.js';
 export async function settingsRoutes(app: FastifyInstance): Promise<void> {
   app.get<{ Params: { eventId: string } }>('/api/events/:eventId/settings', async (req, reply) => {
     const event = eventService.get(req.params.eventId);
-    if (!event) return reply.code(404).send({ error: 'event not found' });
+    if (!event) return reply.code(404).send({ error: 'the server could not find the event' });
     return { settings: settingsService.getForEvent(req.params.eventId) };
   });
 
   app.put<{ Params: { eventId: string } }>('/api/events/:eventId/settings', async (req, reply) => {
     const event = eventService.get(req.params.eventId);
-    if (!event) return reply.code(404).send({ error: 'event not found' });
+    if (!event) return reply.code(404).send({ error: 'the server could not find the event' });
     const parsed = settingsUpdateSchema.safeParse(req.body);
     if (!parsed.success) return reply.code(400).send({ error: parsed.error.flatten() });
     const next = settingsService.updateForEvent(req.params.eventId, parsed.data);

--- a/apps/server/src/services/eventService.ts
+++ b/apps/server/src/services/eventService.ts
@@ -80,7 +80,7 @@ export class EventService {
       payload: { name: input.name },
     });
     const row = db.select().from(events).where(eq(events.id, id)).get();
-    if (!row) throw new Error('event vanished after insert');
+    if (!row) throw new Error('the server could not find the event after the insert');
     logger.info({ eventId: id, name: input.name }, 'event created');
     return rowToDto(row);
   }

--- a/apps/server/src/services/serverLifecycle.ts
+++ b/apps/server/src/services/serverLifecycle.ts
@@ -28,7 +28,7 @@ class ServerLifecycle {
 
   async reload(newConfig: Config): Promise<ReloadResult> {
     if (!this.slots.reload) {
-      throw new Error('serverLifecycle: reload not wired (server not started)');
+      throw new Error('serverLifecycle: the reload slot is empty. The server is not started.');
     }
     return this.slots.reload(newConfig);
   }

--- a/apps/server/src/services/settingsStore.ts
+++ b/apps/server/src/services/settingsStore.ts
@@ -29,7 +29,7 @@ export class SettingsStore {
   }
 
   getDataDir(): string {
-    if (!this.dataDir) throw new Error('settingsStore: dataDir not set');
+    if (!this.dataDir) throw new Error('settingsStore: the data directory is not set');
     return this.dataDir;
   }
 
@@ -46,7 +46,7 @@ export class SettingsStore {
       return parsed;
     }
     if (this.cached) return this.cached;
-    throw new Error('settingsStore: not initialised');
+    throw new Error('settingsStore: the store is not initialized');
   }
 
   /**

--- a/apps/server/src/services/userService.ts
+++ b/apps/server/src/services/userService.ts
@@ -49,7 +49,7 @@ class UserService {
       .values({ id, username, passwordHash, role: input.role ?? 'admin' })
       .run();
     const row = db.select().from(users).where(eq(users.id, id)).get();
-    if (!row) throw new Error('user insert failed');
+    if (!row) throw new Error('the server could not insert the user');
     return rowToDto(row);
   }
 

--- a/apps/web-control/src/components/AuthGate.tsx
+++ b/apps/web-control/src/components/AuthGate.tsx
@@ -44,7 +44,7 @@ export function AuthGate({ children }: { children: React.ReactNode }): JSX.Eleme
   if (state === 'loading') {
     return (
       <div className="flex min-h-screen items-center justify-center bg-zinc-950 text-sm text-zinc-500">
-        Checking session…
+        Please wait…
       </div>
     );
   }
@@ -86,14 +86,14 @@ function LoginForm({ onDone }: { onDone: () => void }): JSX.Element {
     const res = await login(username, password);
     setSubmitting(false);
     if (res.ok) onDone();
-    else setError(res.error ?? 'Login failed');
+    else setError(res.error ?? 'The system could not log you in.');
   };
 
   return (
-    <Shell subtitle="Sign in to the control panel">
+    <Shell subtitle="Log in to the control panel">
       <Field
         id="username"
-        label="Username"
+        label="User name"
         value={username}
         onChange={setUsername}
         autoFocus
@@ -115,7 +115,7 @@ function LoginForm({ onDone }: { onDone: () => void }): JSX.Element {
         disabled={submitting || !username || !password}
         onClick={submit}
       >
-        {submitting ? 'Signing in…' : 'Sign in'}
+        {submitting ? 'Please wait…' : 'Log in'}
       </Button>
     </Shell>
   );
@@ -134,17 +134,18 @@ function SetupForm({ onDone }: { onDone: () => void }): JSX.Element {
     const res = await setup(username, password);
     setSubmitting(false);
     if (res.ok) onDone();
-    else setError(res.error ?? 'Setup failed');
+    else setError(res.error ?? 'The system could not make the account.');
   };
 
   return (
-    <Shell subtitle="Create the admin account">
+    <Shell subtitle="Make the administrator account">
       <p className="text-xs text-zinc-500">
-        First-time setup. Choose the operator login for this Photolive server.
+        This is the first start. Select the operator user name and password for this Photolive
+        server.
       </p>
       <Field
         id="username"
-        label="Username"
+        label="User name"
         value={username}
         onChange={setUsername}
         autoFocus
@@ -157,7 +158,7 @@ function SetupForm({ onDone }: { onDone: () => void }): JSX.Element {
         value={password}
         onChange={setPassword}
         autoComplete="new-password"
-        hint="At least 8 characters."
+        hint="Use 8 characters minimum."
         onEnter={submit}
       />
       {error ? <p className="text-xs text-red-400">{error}</p> : null}
@@ -167,7 +168,7 @@ function SetupForm({ onDone }: { onDone: () => void }): JSX.Element {
         disabled={submitting || !username || !password}
         onClick={submit}
       >
-        {submitting ? 'Creating…' : 'Create account'}
+        {submitting ? 'Please wait…' : 'Make the account'}
       </Button>
     </Shell>
   );

--- a/apps/web-control/src/components/Sidebar.tsx
+++ b/apps/web-control/src/components/Sidebar.tsx
@@ -21,7 +21,7 @@ const NAV = [
   { to: '/live', label: 'Live', icon: Play },
   { to: '/event-settings', label: 'Event settings', icon: SlidersHorizontal },
   { to: '/settings', label: 'Settings', icon: Settings },
-  { to: '/audit', label: 'Audit', icon: FileText },
+  { to: '/audit', label: 'Action log', icon: FileText },
 ] as const;
 
 export function Sidebar(): JSX.Element {
@@ -71,7 +71,7 @@ export function Sidebar(): JSX.Element {
             }}
           >
             <LogOut className="h-3.5 w-3.5" />
-            Sign out
+            Log out
           </Button>
         </div>
       )}

--- a/apps/web-control/src/lib/auth.ts
+++ b/apps/web-control/src/lib/auth.ts
@@ -52,7 +52,7 @@ export async function login(
     password,
   });
   if (ok && data?.user) return { ok: true, user: data.user };
-  return { ok: false, error: 'Invalid username or password' };
+  return { ok: false, error: 'The user name or the password is not correct.' };
 }
 
 export async function setup(
@@ -64,8 +64,10 @@ export async function setup(
     password,
   });
   if (ok && data?.user) return { ok: true, user: data.user };
-  if (status === 409) return { ok: false, error: 'An account already exists. Reload and sign in.' };
-  return { ok: false, error: 'Could not create the account' };
+  if (status === 409) {
+    return { ok: false, error: 'An account is already available. Load the page again and log in.' };
+  }
+  return { ok: false, error: 'The system could not make the account.' };
 }
 
 /**

--- a/apps/web-control/src/lib/utils.ts
+++ b/apps/web-control/src/lib/utils.ts
@@ -9,7 +9,7 @@ export function formatRelativeTime(iso: string | null): string {
   if (!iso) return '—';
   const ms = Date.now() - Date.parse(iso);
   if (!Number.isFinite(ms)) return '—';
-  if (ms < 5_000) return 'just now';
+  if (ms < 5_000) return 'less than 5 s ago';
   if (ms < 60_000) return `${Math.floor(ms / 1000)}s ago`;
   if (ms < 3_600_000) return `${Math.floor(ms / 60_000)}m ago`;
   if (ms < 86_400_000) return `${Math.floor(ms / 3_600_000)}h ago`;

--- a/apps/web-control/src/routes/audit.tsx
+++ b/apps/web-control/src/routes/audit.tsx
@@ -21,9 +21,9 @@ function AuditPage(): JSX.Element {
   if (!activeEvent.data) {
     return (
       <>
-        <PageHeader title="Audit log" />
+        <PageHeader title="Action log" />
         <div className="flex-1 px-6 py-4">
-          <EmptyState message="Activate an event to see its audit log." />
+          <EmptyState message="Make an event active to see its action log." />
         </div>
       </>
     );
@@ -31,7 +31,7 @@ function AuditPage(): JSX.Element {
 
   return (
     <>
-      <PageHeader title="Audit log" subtitle={activeEvent.data.name} />
+      <PageHeader title="Action log" subtitle={activeEvent.data.name} />
       <div className="flex-1 overflow-auto px-6 py-4 font-mono text-xs">
         {audit.data && audit.data.length > 0 ? (
           <div className="rounded-md border border-zinc-800">
@@ -39,9 +39,9 @@ function AuditPage(): JSX.Element {
               <THead>
                 <tr>
                   <TH className="w-44">Time</TH>
-                  <TH className="w-24">Actor</TH>
+                  <TH className="w-24">User</TH>
                   <TH className="w-56">Action</TH>
-                  <TH>Payload</TH>
+                  <TH>Data</TH>
                 </tr>
               </THead>
               <TBody>
@@ -61,7 +61,7 @@ function AuditPage(): JSX.Element {
             </Table>
           </div>
         ) : (
-          <EmptyState message="No audit entries yet." />
+          <EmptyState message="There are no log entries." />
         )}
       </div>
     </>

--- a/apps/web-control/src/routes/event-settings.tsx
+++ b/apps/web-control/src/routes/event-settings.tsx
@@ -32,7 +32,7 @@ function SettingsPage(): JSX.Element {
       <>
         <PageHeader title="Settings" />
         <div className="flex-1 px-6 py-4">
-          <EmptyState message="Activate an event to edit its settings." />
+          <EmptyState message="Make an event active to change its settings." />
         </div>
       </>
     );
@@ -42,7 +42,7 @@ function SettingsPage(): JSX.Element {
     return (
       <>
         <PageHeader title="Settings" subtitle={activeEvent.data.name} />
-        <div className="flex-1 px-6 py-4 text-sm text-zinc-500">Loading…</div>
+        <div className="flex-1 px-6 py-4 text-sm text-zinc-500">Please wait…</div>
       </>
     );
   }
@@ -96,7 +96,7 @@ function SettingsForm({
               disabled={!dirty || save.isPending}
               onClick={() => save.mutate(draft)}
             >
-              {save.isPending ? 'Saving…' : 'Save'}
+              {save.isPending ? 'Please wait…' : 'Save'}
             </Button>
           </div>
         }
@@ -110,7 +110,7 @@ function SettingsForm({
 
             <Field
               label="Interval"
-              hint="Time on screen per image"
+              hint="The time on the screen for each image."
               control={
                 <div className="flex items-center gap-2">
                   <Input
@@ -178,35 +178,33 @@ function SettingsForm({
             </h2>
 
             <ToggleField
-              label="Show photographer attribution"
+              label="Show the name of the photographer"
               checked={draft.showPhotographer}
               onChange={(v) => setDraft({ ...draft, showPhotographer: v })}
             />
             <ToggleField
-              label="Show live caption"
+              label="Show the caption"
               checked={draft.showCaption}
               onChange={(v) => setDraft({ ...draft, showCaption: v })}
             />
             <ToggleField
-              label='Show "time since shot"'
+              label="Show the age of the image"
               checked={draft.showTimeAgo}
               onChange={(v) => setDraft({ ...draft, showTimeAgo: v })}
             />
             <ToggleField
-              label="Show event branding"
+              label="Show the name of the event"
               checked={draft.showBranding}
               onChange={(v) => setDraft({ ...draft, showBranding: v })}
             />
           </section>
 
           <section className="space-y-4">
-            <h2 className="text-xs font-semibold uppercase tracking-wider text-zinc-500">
-              OBS / compositing
-            </h2>
+            <h2 className="text-xs font-semibold uppercase tracking-wider text-zinc-500">OBS</h2>
 
             <ToggleField
               label="Transparent background"
-              hint="Drops the black backdrop so an OBS Browser Source can composite the slideshow over the scene below. Letterboxing around portrait images becomes transparent too."
+              hint="This removes the black background. Thus an OBS browser source can show the slideshow above the scene below it. The borders around the vertical images also become transparent."
               checked={draft.transparentBackground}
               onChange={(v) => setDraft({ ...draft, transparentBackground: v })}
             />
@@ -218,8 +216,8 @@ function SettingsForm({
             </h2>
 
             <Field
-              label="Blur threshold"
-              hint="Used in auto-skip-blurry mode. Higher = stricter. Typical range 50–200."
+              label="Sharpness limit"
+              hint="An image with a sharpness score below this limit does not go to the slideshow. A higher value rejects more images. The usual range is 50 to 200."
               control={
                 <Input
                   type="number"

--- a/apps/web-control/src/routes/events.tsx
+++ b/apps/web-control/src/routes/events.tsx
@@ -64,7 +64,7 @@ function EventsPage(): JSX.Element {
 
       <div className="flex-1 overflow-auto px-6 py-4">
         {events.isLoading ? (
-          <p className="text-sm text-zinc-500">Loading…</p>
+          <p className="text-sm text-zinc-500">Please wait…</p>
         ) : events.data && events.data.length > 0 ? (
           <div className="rounded-md border border-zinc-800">
             <Table>
@@ -73,7 +73,7 @@ function EventsPage(): JSX.Element {
                   <TH>Name</TH>
                   <TH>Slug</TH>
                   <TH>Mode</TH>
-                  <TH>Created</TH>
+                  <TH>Made at</TH>
                   <TH>State</TH>
                   <TH className="text-right">Actions</TH>
                 </tr>
@@ -93,7 +93,7 @@ function EventsPage(): JSX.Element {
                       ) : event.isActive ? (
                         <Badge tone="active">active</Badge>
                       ) : (
-                        <Badge tone="neutral">inactive</Badge>
+                        <Badge tone="neutral">not active</Badge>
                       )}
                     </TD>
                     <TD className="text-right">
@@ -105,7 +105,7 @@ function EventsPage(): JSX.Element {
                             onClick={() => activate.mutate(event.id)}
                           >
                             <Power className="h-3 w-3" />
-                            Activate
+                            Make active
                           </Button>
                         )}
                         {!event.archivedAt ? (
@@ -122,17 +122,17 @@ function EventsPage(): JSX.Element {
                             size="sm"
                             variant="ghost"
                             onClick={() => unarchive.mutate(event.id)}
-                            title="Restore from archive (does not activate)"
+                            title="Move the event out of the archive. The event does not become active."
                           >
                             <ArchiveRestore className="h-3 w-3" />
-                            Unarchive
+                            Restore
                           </Button>
                         )}
                         <Button
                           size="sm"
                           variant="ghost"
                           onClick={() => setConfirmDelete(event)}
-                          title="Delete permanently"
+                          title="Delete completely"
                         >
                           <Trash2 className="h-3 w-3" />
                         </Button>
@@ -145,11 +145,11 @@ function EventsPage(): JSX.Element {
           </div>
         ) : (
           <EmptyState
-            message="No events yet."
+            message="There are no events."
             action={
               <Button variant="primary" onClick={() => setCreateOpen(true)}>
                 <Plus className="h-3.5 w-3.5" />
-                Create the first event
+                Make the first event
               </Button>
             }
           />
@@ -192,16 +192,16 @@ function DeleteEventDialog({
     <Dialog open={Boolean(event)} onOpenChange={onOpenChange}>
       <DialogContent>
         <DialogHeader>
-          <DialogTitle>Delete event permanently?</DialogTitle>
+          <DialogTitle>Delete the event completely?</DialogTitle>
           <DialogDescription>
-            This removes <strong>{event.name}</strong> and all its photographers, images, settings,
-            and audit history. The photos directory and rendered thumbnails on disk are also
-            deleted. This cannot be undone.
+            This deletes <strong>{event.name}</strong> with its photographers, images, settings and
+            log entries. This also deletes the photo directory and the thumbnail files from the
+            disk. You cannot undo this operation.
           </DialogDescription>
         </DialogHeader>
         <div className="flex flex-col gap-1.5">
           <Label htmlFor="confirm-slug">
-            Type the slug <span className="font-mono text-zinc-300">{event.slug}</span> to confirm
+            Write the slug <span className="font-mono text-zinc-300">{event.slug}</span> to continue
           </Label>
           <Input
             id="confirm-slug"
@@ -214,7 +214,9 @@ function DeleteEventDialog({
         </div>
         {remove.error ? (
           <p className="text-xs text-red-400">
-            {remove.error instanceof Error ? remove.error.message : 'Delete failed'}
+            {remove.error instanceof Error
+              ? remove.error.message
+              : 'The system could not delete the event.'}
           </p>
         ) : null}
         <DialogFooter>
@@ -229,7 +231,7 @@ function DeleteEventDialog({
             disabled={!matches || remove.isPending}
             onClick={() => remove.mutate(event.id)}
           >
-            {remove.isPending ? 'Deleting…' : 'Delete permanently'}
+            {remove.isPending ? 'Please wait…' : 'Delete completely'}
           </Button>
         </DialogFooter>
       </DialogContent>
@@ -291,7 +293,7 @@ function CreateEventDialog({
       onOpenChange(false);
     },
     onError: (e) => {
-      setError(e instanceof Error ? e.message : 'Failed to create event');
+      setError(e instanceof Error ? e.message : 'The system could not make the event.');
     },
   });
 
@@ -301,8 +303,9 @@ function CreateEventDialog({
         <DialogHeader>
           <DialogTitle>New event</DialogTitle>
           <DialogDescription>
-            Photos arrive into <span className="font-mono text-zinc-300">photos dir</span>; one
-            event is active at a time.
+            The cameras send the photos to the{' '}
+            <span className="font-mono text-zinc-300">photos directory</span>. Only one event can be
+            active.
           </DialogDescription>
         </DialogHeader>
         <form
@@ -347,22 +350,24 @@ function CreateEventDialog({
               className="font-mono"
             />
             <p className="text-xs text-zinc-500">
-              Relative names are created as a subfolder of the server's photos folder. Use an
-              absolute path (e.g. a network share) for a custom location.
+              A relative name makes a subfolder in the photo folder of the server. For a different
+              location, write a full path, for example a network folder.
             </p>
           </div>
           <div className="flex flex-col gap-1.5">
-            <Label htmlFor="displayMode">Curation mode</Label>
+            <Label htmlFor="displayMode">Selection mode</Label>
             <Select value={displayMode} onValueChange={setDisplayMode}>
               <SelectTrigger id="displayMode">
                 <SelectValue />
               </SelectTrigger>
               <SelectContent>
-                <SelectItem value="auto">auto — display everything</SelectItem>
+                <SelectItem value="auto">automatic — show all the images</SelectItem>
                 <SelectItem value="auto-skip-blurry">
-                  auto-skip-blurry — hide low-sharpness shots
+                  automatic, no blurred — hide the images that are not sharp
                 </SelectItem>
-                <SelectItem value="approval">approval — operator gates each image</SelectItem>
+                <SelectItem value="approval">
+                  approval — the operator approves each image
+                </SelectItem>
               </SelectContent>
             </Select>
           </div>
@@ -374,7 +379,7 @@ function CreateEventDialog({
               </Button>
             </DialogClose>
             <Button type="submit" variant="primary" disabled={create.isPending}>
-              {create.isPending ? 'Creating…' : 'Create'}
+              {create.isPending ? 'Please wait…' : 'Make'}
             </Button>
           </DialogFooter>
         </form>

--- a/apps/web-control/src/routes/live.tsx
+++ b/apps/web-control/src/routes/live.tsx
@@ -66,7 +66,7 @@ function LivePage(): JSX.Element {
       <>
         <PageHeader title="Live" />
         <div className="flex-1 px-6 py-4">
-          <EmptyState message="Activate an event first." />
+          <EmptyState message="Make an event active first." />
         </div>
       </>
     );
@@ -92,23 +92,28 @@ function LivePage(): JSX.Element {
 
         <div className="flex items-center justify-between rounded-md border border-zinc-800 bg-zinc-950 px-3 py-2">
           <div className="flex items-center gap-1">
-            <Button size="icon" variant="ghost" onClick={() => send('prev')} title="Previous (←)">
+            <Button
+              size="icon"
+              variant="ghost"
+              onClick={() => send('prev')}
+              title="Previous image (←)"
+            >
               <SkipBack className="h-4 w-4" />
             </Button>
             <Button
               size="icon"
               variant="ghost"
               onClick={() => send(state?.isPlaying ? 'pause' : 'resume')}
-              title={state?.isPlaying ? 'Pause (Space)' : 'Resume (Space)'}
+              title={state?.isPlaying ? 'Stop (Space)' : 'Continue (Space)'}
             >
               {state?.isPlaying ? <Pause className="h-4 w-4" /> : <Play className="h-4 w-4" />}
             </Button>
-            <Button size="icon" variant="ghost" onClick={() => send('next')} title="Next (→)">
+            <Button size="icon" variant="ghost" onClick={() => send('next')} title="Next image (→)">
               <SkipForward className="h-4 w-4" />
             </Button>
           </div>
           <div className="font-mono text-xs tabular-nums text-zinc-500">
-            queue: {state?.queueLength ?? 0} · pending: {state?.pendingCount ?? 0}
+            queue: {state?.queueLength ?? 0} · to approve: {state?.pendingCount ?? 0}
           </div>
         </div>
       </div>
@@ -161,7 +166,7 @@ function LatencyBadge({ ms }: { ms: number | null }): JSX.Element {
   return (
     <span className={cn('flex items-center gap-1.5 font-mono text-xs tabular-nums', tone)}>
       <Activity className="h-3.5 w-3.5" />
-      latency {formatLatency(ms)}
+      delay {formatLatency(ms)}
     </span>
   );
 }
@@ -179,7 +184,7 @@ function CaptionBox({
 
   const save = useMutation({
     mutationFn: () => {
-      if (!imageId) throw new Error('no image');
+      if (!imageId) throw new Error('there is no current image');
       return api.images.setCaption(imageId, text);
     },
     onSuccess: () => qc.invalidateQueries({ queryKey: ['queue'] }),
@@ -194,7 +199,7 @@ function CaptionBox({
       }}
     >
       <Input
-        placeholder={imageId ? 'Caption (Enter to save)' : 'No current image'}
+        placeholder={imageId ? 'Caption. Push Enter to save.' : 'There is no current image.'}
         disabled={!imageId}
         value={text}
         onChange={(e) => setText(e.target.value)}

--- a/apps/web-control/src/routes/photographers.tsx
+++ b/apps/web-control/src/routes/photographers.tsx
@@ -49,7 +49,7 @@ function PhotographersPage(): JSX.Element {
       <>
         <PageHeader title="Photographers" />
         <div className="flex-1 px-6 py-4">
-          <EmptyState message="Activate an event first to manage its photographers." />
+          <EmptyState message="Make an event active before you add photographers to it." />
         </div>
       </>
     );
@@ -101,7 +101,7 @@ function PhotographersPage(): JSX.Element {
                       {p.isActive ? (
                         <Badge tone="active">active</Badge>
                       ) : (
-                        <Badge tone="neutral">inactive</Badge>
+                        <Badge tone="neutral">not active</Badge>
                       )}
                     </TD>
                     <TD className="text-right">
@@ -110,26 +110,26 @@ function PhotographersPage(): JSX.Element {
                           size="sm"
                           variant="ghost"
                           onClick={() => setInfoView(p)}
-                          title="Show FTP info (host / username, no password)"
+                          title="Show the FTP data. The password does not show."
                         >
                           <Eye className="h-3 w-3" />
-                          Info
+                          Details
                         </Button>
                         <Button
                           size="sm"
                           variant="ghost"
                           disabled={rotate.isPending}
                           onClick={() => rotate.mutate(p.id)}
-                          title="Generate a new FTP password (invalidates the old one)"
+                          title="Make a new FTP password. The server refuses the old password."
                         >
                           <RefreshCw className="h-3 w-3" />
-                          Rotate
+                          Replace
                         </Button>
                         <Button
                           size="sm"
                           variant="ghost"
                           onClick={() => setConfirmDelete(p)}
-                          title="Delete photographer"
+                          title="Delete the photographer"
                         >
                           <Trash2 className="h-3 w-3" />
                         </Button>
@@ -142,11 +142,11 @@ function PhotographersPage(): JSX.Element {
           </div>
         ) : (
           <EmptyState
-            message="No photographers in this event yet."
+            message="This event has no photographers."
             action={
               <Button variant="primary" onClick={() => setCreateOpen(true)}>
                 <Plus className="h-3.5 w-3.5" />
-                Add the first one
+                Add the first photographer
               </Button>
             }
           />
@@ -155,7 +155,8 @@ function PhotographersPage(): JSX.Element {
 
       {rotate.error ? (
         <div className="px-6 pb-2 text-xs text-red-400">
-          Rotate failed: {rotate.error instanceof Error ? rotate.error.message : 'unknown error'}
+          The system could not replace the password:{' '}
+          {rotate.error instanceof Error ? rotate.error.message : 'unknown error'}
         </div>
       ) : null}
 
@@ -204,7 +205,7 @@ function CameraFtpSettings({
   return (
     <div className="space-y-3">
       <div className="rounded border border-zinc-800 bg-zinc-900/50 px-3 py-2 text-xs text-zinc-400">
-        On the camera:{' '}
+        On the camera, go to:{' '}
         <span className="text-zinc-300">
           Network → FTP Transfer Func. → Server Setting → Server 1
         </span>
@@ -212,7 +213,7 @@ function CameraFtpSettings({
       <dl className="grid grid-cols-[max-content_1fr] gap-x-4 gap-y-2 text-sm">
         <dt className="text-zinc-500">Display Name</dt>
         <dd className="font-mono text-zinc-50">
-          PhotoLive <span className="text-zinc-500 italic">(any label)</span>
+          PhotoLive <span className="text-zinc-500 italic">(any name)</span>
         </dd>
 
         <dt className="text-zinc-500">Host Name</dt>
@@ -231,7 +232,7 @@ function CameraFtpSettings({
         </dd>
 
         <dt className="text-zinc-500">Specify Directory</dt>
-        <dd className="font-mono text-zinc-500 italic">leave empty</dd>
+        <dd className="font-mono text-zinc-500 italic">keep empty</dd>
 
         <dt className="text-zinc-500">User</dt>
         <dd className="flex items-center gap-1.5 font-mono text-zinc-50">
@@ -246,15 +247,17 @@ function CameraFtpSettings({
             <CopyButton value={password} />
           </dd>
         ) : (
-          <dd className="text-zinc-500 italic">not retrievable — rotate to issue a new one</dd>
+          <dd className="text-zinc-500 italic">
+            not available. Replace the password to make a new one.
+          </dd>
         )}
 
         <dt className="text-zinc-500">Passive Mode</dt>
         <dd className="font-mono text-zinc-50">On</dd>
       </dl>
       <p className="text-xs text-zinc-400">
-        Then enable{' '}
-        <span className="text-zinc-300">Network → FTP Transfer Func. → FTP Function: On</span>.
+        Then set <span className="text-zinc-300">Network → FTP Transfer Func. → FTP Function</span>{' '}
+        to <span className="text-zinc-300">On</span>.
       </p>
     </div>
   );
@@ -273,10 +276,11 @@ function FtpInfoDialog({
     <Dialog open={Boolean(photographer)} onOpenChange={onOpenChange}>
       <DialogContent>
         <DialogHeader>
-          <DialogTitle>FTP info for {photographer.displayName}</DialogTitle>
+          <DialogTitle>FTP data for {photographer.displayName}</DialogTitle>
           <DialogDescription>
-            The password is hashed on the server and can't be retrieved. If you need to share
-            credentials again, click <strong>Rotate</strong> to generate a new password.
+            The server keeps only a hash of the password. Thus you cannot see the password again. To
+            give the password to the photographer again, select <strong>Replace</strong>. This makes
+            a new password.
           </DialogDescription>
         </DialogHeader>
         <CameraFtpSettings host={host} port={port} username={photographer.ftpUsername} />
@@ -317,15 +321,17 @@ function DeletePhotographerDialog({
     <Dialog open={Boolean(photographer)} onOpenChange={onOpenChange}>
       <DialogContent>
         <DialogHeader>
-          <DialogTitle>Delete photographer?</DialogTitle>
+          <DialogTitle>Delete the photographer?</DialogTitle>
           <DialogDescription>
-            <strong>{photographer.displayName}</strong> will be removed and their FTP credentials
-            invalidated. Photos they already uploaded stay attributed to them historically.
+            The system deletes <strong>{photographer.displayName}</strong> and refuses their FTP
+            user name. The images that they sent keep their name.
           </DialogDescription>
         </DialogHeader>
         {remove.error ? (
           <p className="text-xs text-red-400">
-            {remove.error instanceof Error ? remove.error.message : 'Delete failed'}
+            {remove.error instanceof Error
+              ? remove.error.message
+              : 'The system could not delete the photographer.'}
           </p>
         ) : null}
         <DialogFooter>
@@ -340,7 +346,7 @@ function DeletePhotographerDialog({
             disabled={remove.isPending}
             onClick={() => remove.mutate(photographer.id)}
           >
-            {remove.isPending ? 'Deleting…' : 'Delete'}
+            {remove.isPending ? 'Please wait…' : 'Delete'}
           </Button>
         </DialogFooter>
       </DialogContent>
@@ -383,10 +389,10 @@ function CreatePhotographerDialog({
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent>
         <DialogHeader>
-          <DialogTitle>Add photographer</DialogTitle>
+          <DialogTitle>Add a photographer</DialogTitle>
           <DialogDescription>
-            FTP credentials are issued automatically. The password is shown <strong>once</strong>{' '}
-            after creation — you can rotate it anytime.
+            The server makes the FTP user name and the password automatically. The password shows{' '}
+            <strong>one time only</strong>. You can replace it when necessary.
           </DialogDescription>
         </DialogHeader>
         <form
@@ -431,7 +437,7 @@ function CreatePhotographerDialog({
               </Button>
             </DialogClose>
             <Button type="submit" variant="primary" disabled={create.isPending}>
-              {create.isPending ? 'Creating…' : 'Create'}
+              {create.isPending ? 'Please wait…' : 'Add'}
             </Button>
           </DialogFooter>
         </form>
@@ -468,10 +474,9 @@ function SecretRevealDialog({
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent>
         <DialogHeader>
-          <DialogTitle>FTP credentials for {photographer.displayName}</DialogTitle>
+          <DialogTitle>FTP user name and password for {photographer.displayName}</DialogTitle>
           <DialogDescription>
-            This is the only time the password is shown. Save it or scan the QR code from the
-            camera.
+            The password shows one time only. Write it down, or read the QR code with the camera.
           </DialogDescription>
         </DialogHeader>
         <CameraFtpSettings
@@ -484,7 +489,7 @@ function SecretRevealDialog({
           <div className="flex justify-center pt-2">
             <img
               src={qr}
-              alt="FTP credentials QR code"
+              alt="QR code with the FTP data"
               className="rounded border border-zinc-800"
             />
           </div>

--- a/apps/web-control/src/routes/queue.tsx
+++ b/apps/web-control/src/routes/queue.tsx
@@ -23,7 +23,7 @@ function QueuePage(): JSX.Element {
       <>
         <PageHeader title="Queue" />
         <div className="flex-1 px-6 py-4">
-          <EmptyState message="Activate an event to view its queue." />
+          <EmptyState message="Make an event active to see its queue." />
         </div>
       </>
     );
@@ -60,9 +60,9 @@ function TabBar({
 
   const tabs: { id: Tab; label: string; count: number }[] = [
     { id: 'approved', label: 'Approved', count: counts.data?.approved ?? 0 },
-    { id: 'pending', label: 'Pending', count: counts.data?.pending ?? 0 },
-    { id: 'auto-skipped', label: 'Skipped', count: counts.data?.['auto-skipped'] ?? 0 },
-    { id: 'excluded', label: 'Excluded', count: counts.data?.excluded ?? 0 },
+    { id: 'pending', label: 'To approve', count: counts.data?.pending ?? 0 },
+    { id: 'auto-skipped', label: 'Blurred', count: counts.data?.['auto-skipped'] ?? 0 },
+    { id: 'excluded', label: 'Hidden', count: counts.data?.excluded ?? 0 },
   ];
 
   return (
@@ -102,7 +102,7 @@ function ImageGrid({ eventId, tab }: { eventId: string; tab: Tab }): JSX.Element
   });
 
   if (images.isLoading) {
-    return <p className="px-6 py-4 text-sm text-zinc-500">Loading…</p>;
+    return <p className="px-6 py-4 text-sm text-zinc-500">Please wait…</p>;
   }
 
   if (!images.data || images.data.length === 0) {
@@ -110,12 +110,12 @@ function ImageGrid({ eventId, tab }: { eventId: string; tab: Tab }): JSX.Element
       <EmptyState
         message={
           tab === 'pending'
-            ? 'Nothing pending. Approval-mode events will land photos here as they arrive.'
+            ? 'There are no images to approve. In the approval mode, each new image comes here first.'
             : tab === 'auto-skipped'
-              ? 'No images auto-skipped (yet).'
+              ? 'The system found no blurred images.'
               : tab === 'excluded'
-                ? 'No images excluded.'
-                : 'No approved images yet.'
+                ? 'There are no hidden images.'
+                : 'There are no approved images.'
         }
       />
     );
@@ -176,7 +176,9 @@ function ImageCell({ image, tab }: { image: ImageDto; tab: Tab }): JSX.Element {
         ) : null}
       </div>
       <div className="flex items-center justify-between gap-1 px-2 py-1.5 text-xs">
-        <span className="truncate text-zinc-400">{image.photographerName ?? 'unattributed'}</span>
+        <span className="truncate text-zinc-400">
+          {image.photographerName ?? 'no photographer'}
+        </span>
         <span className="shrink-0 font-mono text-[10px] tabular-nums text-zinc-500">
           {new Date(image.uploadedAt).toLocaleTimeString([], {
             hour: '2-digit',
@@ -204,14 +206,14 @@ function ImageCell({ image, tab }: { image: ImageDto; tab: Tab }): JSX.Element {
           <ActionBtn
             onClick={() => exclude.mutate()}
             icon={<EyeOff className="h-3.5 w-3.5" />}
-            label="Exclude"
+            label="Hide"
             tone="neutral"
           />
         ) : (
           <ActionBtn
             onClick={() => include.mutate()}
             icon={<Eye className="h-3.5 w-3.5" />}
-            label="Include"
+            label="Show"
             tone="neutral"
           />
         )}

--- a/apps/web-control/src/routes/settings.tsx
+++ b/apps/web-control/src/routes/settings.tsx
@@ -33,7 +33,7 @@ function AppSettingsPage(): JSX.Element {
     return (
       <>
         <PageHeader title="Settings" />
-        <div className="flex-1 px-6 py-4 text-sm text-zinc-500">Loading…</div>
+        <div className="flex-1 px-6 py-4 text-sm text-zinc-500">Please wait…</div>
       </>
     );
   }
@@ -88,7 +88,7 @@ function SettingsForm({
     <>
       <PageHeader
         title="Settings"
-        subtitle={inElectron ? 'Photolive desktop' : 'Read-only — running outside the desktop app'}
+        subtitle={inElectron ? 'Photolive desktop' : 'Read-only outside the desktop app'}
         actions={
           <div className="flex items-center gap-2">
             {savedAt && !dirty ? <span className="text-xs text-zinc-500">saved</span> : null}
@@ -100,7 +100,7 @@ function SettingsForm({
               disabled={!editable || !dirty || save.isPending}
               onClick={onSave}
             >
-              {save.isPending ? 'Saving…' : 'Save'}
+              {save.isPending ? 'Please wait…' : 'Save'}
             </Button>
           </div>
         }
@@ -110,17 +110,17 @@ function SettingsForm({
         <div className="mx-auto max-w-3xl space-y-8">
           {!mutable ? (
             <Banner intent="info">
-              The server was launched from a <code>.env</code> file, so settings can't be edited
-              from the UI. Edit your <code>.env</code> at <code>{data.dataDir}/.env</code> (or
-              wherever it lives) and restart the server, or run with{' '}
+              The server started from a <code>.env</code> file. Thus you cannot change the settings
+              here. Change the <code>.env</code> file at <code>{data.dataDir}/.env</code>, then
+              start the server again. As an alternative, start the server with{' '}
               <code>--settings &lt;path/to/settings.json&gt;</code>.
             </Banner>
           ) : null}
 
           {!inElectron && mutable ? (
             <Banner intent="info">
-              You're viewing this page in a browser tab. App-level settings can only be mutated from
-              the Photolive desktop app. View-only here.
+              You opened this page in a browser tab. Only the Photolive desktop app can change the
+              app settings. This page shows them read-only.
             </Banner>
           ) : null}
 
@@ -128,7 +128,8 @@ function SettingsForm({
             <Banner intent="warn">
               <div className="space-y-2">
                 <div>
-                  Saved. Some changes need a full restart before they take effect:
+                  The system saved the settings. These changes become effective only after a
+                  restart:
                   <ul className="ml-5 mt-1 list-disc text-xs">
                     {reload.reasons.map((r) => (
                       <li key={r}>{r}</li>
@@ -140,7 +141,7 @@ function SettingsForm({
                     Restart now
                   </Button>
                 ) : (
-                  <p className="text-xs">Quit and relaunch the desktop app to apply.</p>
+                  <p className="text-xs">Close the desktop app, then start it again.</p>
                 )}
               </div>
             </Banner>
@@ -197,7 +198,7 @@ function SectionGeneral({
     <Section title="General">
       <Field
         label="Log level"
-        hint="pino verbosity. trace is most verbose, fatal least."
+        hint="The quantity of detail in the log. trace gives the most detail, fatal the least."
         control={
           <Select
             value={draft.logLevel}
@@ -223,14 +224,14 @@ function SectionGeneral({
 
       <Field
         label="Data directory"
-        hint="Resolved at startup. Override under Storage to change."
+        hint="The app finds this directory at start. To use a different one, set the override in Storage."
         control={
           <div className="flex items-center gap-2">
             <code className="rounded bg-zinc-900 px-2 py-1 text-xs text-zinc-300">{dataDir}</code>
             {inElectron ? (
               <Button variant="ghost" size="sm" onClick={() => void revealDataDir()}>
                 <FolderOpen className="h-3.5 w-3.5" />
-                Reveal
+                Open the folder
               </Button>
             ) : null}
           </div>
@@ -250,11 +251,11 @@ function SectionGeneral({
 
       {inElectron ? (
         <Field
-          label="Logs"
+          label="Log files"
           control={
             <Button variant="ghost" size="sm" onClick={() => void openLogs()}>
               <FolderOpen className="h-3.5 w-3.5" />
-              Open logs folder
+              Open the log folder
             </Button>
           }
         />
@@ -273,10 +274,10 @@ function SectionNetwork({
   editable: boolean;
 }): JSX.Element {
   return (
-    <Section title="Network" badge="Restart required">
+    <Section title="Network" badge="Restart necessary">
       <Field
         label="HTTP port"
-        hint="Slideshow + control panel + WebSocket all listen here."
+        hint="The slideshow, the control panel and the WebSocket all use this port."
         control={
           <Input
             type="number"
@@ -297,7 +298,7 @@ function SectionNetwork({
 
       <Field
         label="Bind host"
-        hint='"0.0.0.0" for LAN access (e.g. OBS browser source on another machine), "127.0.0.1" for local-only.'
+        hint='Write "0.0.0.0" to permit access from the local network, for example an OBS browser source on a different machine. Write "127.0.0.1" to permit access from this machine only.'
         control={
           <Input
             value={draft.network.host}
@@ -312,7 +313,7 @@ function SectionNetwork({
 
       <Field
         label="Allowed origins"
-        hint="Comma-separated CORS origins. http://127.0.0.1:<port> and http://localhost:<port> are auto-allowed."
+        hint="A list of CORS origins. Put a comma between two origins. The server always permits http://127.0.0.1:<port> and http://localhost:<port>."
         control={
           <Input
             value={draft.network.allowedOrigins.join(', ')}
@@ -360,10 +361,10 @@ function SectionStorage({
   };
 
   return (
-    <Section title="Storage" badge="Restart required">
+    <Section title="Storage" badge="Restart necessary">
       <Field
         label="Data directory override"
-        hint="Leave blank to auto-detect (next to the app exe, falling back to userData)."
+        hint="Keep this field empty to let the app select the directory. The app uses the data folder adjacent to the program file. If that folder is read-only, the app uses the user-data folder."
         control={
           <PathInput
             value={draft.storage.dataDir ?? ''}
@@ -379,7 +380,7 @@ function SectionStorage({
 
       <Field
         label="Photos root"
-        hint="Where uploaded JPEGs land. Defaults to <dataDir>/photos."
+        hint="The directory for the JPEG files from the cameras. The default is <dataDir>/photos."
         control={
           <PathInput
             value={draft.storage.photosRoot ?? ''}
@@ -395,7 +396,7 @@ function SectionStorage({
 
       <Field
         label="Renditions root"
-        hint="Where Sharp emits the resized + thumbnail outputs. Defaults to <dataDir>/renditions."
+        hint="The directory for the display images and the thumbnail images. The default is <dataDir>/renditions."
         control={
           <PathInput
             value={draft.storage.renditionsRoot ?? ''}
@@ -452,7 +453,7 @@ function SectionFtp({
       />
       <Field
         label="PASV advertised URL"
-        hint="What the camera sees as the data-channel host. Usually the LAN IP of this machine."
+        hint="The data-channel host that the camera receives. Usually this is the local network address of this machine."
         control={
           <Input
             value={draft.ftp.pasvUrl}
@@ -511,7 +512,7 @@ function SectionObs({
     <Section title="OBS WebSocket">
       <Field
         label="WebSocket URL"
-        hint="From OBS: Tools → WebSocket Server Settings. Leave empty to disable the integration."
+        hint="Find this address in OBS: Tools → WebSocket Server Settings. Keep the field empty to stop the OBS connection."
         control={
           <Input
             type="text"
@@ -534,7 +535,7 @@ function SectionObs({
               setDraft({ ...draft, obs: { ...draft.obs, password: e.target.value } })
             }
             className="w-72 font-mono"
-            placeholder="(leave blank for no password)"
+            placeholder="(keep empty if there is no password)"
           />
         }
       />
@@ -572,7 +573,7 @@ function SectionAuth({
     <Section title="Display token">
       <Field
         label="Token"
-        hint="View-only token for the audience slideshow / OBS browser source / Chromecast — pass it as ?token=… in the slideshow URL. It can't change anything. Operators sign in with a username & password instead."
+        hint="This token gives read-only access to the slideshow, the OBS browser source and the Chromecast. Put it in the slideshow address as ?token=…. The token cannot change data. Operators log in with a user name and a password."
         control={
           <div className="flex items-center gap-2">
             <code
@@ -593,7 +594,7 @@ function SectionAuth({
               disabled={reveal.isPending}
             >
               {revealed ? <EyeOff className="h-3.5 w-3.5" /> : <Eye className="h-3.5 w-3.5" />}
-              {revealed ? 'Hide' : 'Reveal'}
+              {revealed ? 'Hide' : 'Show'}
             </Button>
             {revealed ? (
               <Button
@@ -612,13 +613,13 @@ function SectionAuth({
       />
 
       <Field
-        label="Rotate"
-        hint="Generates a fresh 256-bit display token and invalidates the old one immediately. Slideshow / OBS clients must reconnect with the new token; operator logins are unaffected."
+        label="Replace"
+        hint="This makes a new 256-bit display token. The server refuses the old token immediately. The slideshow clients and the OBS clients must connect again with the new token. This does not change the operator logins."
         control={
           confirmingRotate ? (
             <div className="flex items-center gap-2">
               <span className="text-xs text-zinc-300">
-                Rotate now? Existing sessions will drop.
+                Replace the token now? The server closes the slideshow connections.
               </span>
               <Button
                 variant="primary"
@@ -626,7 +627,7 @@ function SectionAuth({
                 onClick={() => rotate.mutate()}
                 disabled={rotate.isPending}
               >
-                {rotate.isPending ? 'Rotating…' : 'Confirm'}
+                {rotate.isPending ? 'Please wait…' : 'Replace'}
               </Button>
               <Button variant="ghost" size="sm" onClick={() => setConfirmingRotate(false)}>
                 Cancel
@@ -640,7 +641,7 @@ function SectionAuth({
               disabled={!editable}
             >
               <RotateCw className="h-3.5 w-3.5" />
-              Rotate token
+              Replace the token
             </Button>
           )
         }
@@ -716,7 +717,7 @@ function PathInput({
       {onPick ? (
         <Button variant="ghost" size="sm" onClick={() => void onPick()} disabled={disabled}>
           <FolderOpen className="h-3.5 w-3.5" />
-          Browse
+          Select folder
         </Button>
       ) : null}
     </div>

--- a/apps/web-slideshow/src/App.tsx
+++ b/apps/web-slideshow/src/App.tsx
@@ -34,6 +34,13 @@ interface Connection {
 
 type AuthStatus = 'ok' | 'missing-token' | 'invalid-token';
 
+/** The label for each connection state. See docs/string-style-guide.md. */
+const CONNECTION_LABEL: Record<Connection['state'], string> = {
+  connecting: 'connection in progress',
+  open: 'connected',
+  closed: 'no connection',
+};
+
 export function App(): JSX.Element {
   const [event, setEvent] = React.useState<EventDto | null>(null);
   const [settings, setSettings] = React.useState<SettingsDto>(DEFAULT_SETTINGS);
@@ -218,7 +225,7 @@ export function App(): JSX.Element {
     return <AuthError status={authStatus} />;
   }
   if (!event) {
-    return <ConnectionState conn={conn} message="Waiting for active event…" />;
+    return <ConnectionState conn={conn} message="Wait for an active event…" />;
   }
 
   return (
@@ -335,7 +342,7 @@ function TimeAgo({ iso }: { iso: string }): JSX.Element {
   }, []);
   const ms = Date.now() - Date.parse(iso);
   let text = '';
-  if (ms < 60_000) text = 'just now';
+  if (ms < 60_000) text = 'less than 1 min ago';
   else if (ms < 3_600_000) text = `${Math.floor(ms / 60_000)} min ago`;
   else text = `${Math.floor(ms / 3_600_000)} h ago`;
   return <div className="absolute bottom-6 right-6 font-mono text-xs text-zinc-400">{text}</div>;
@@ -343,11 +350,12 @@ function TimeAgo({ iso }: { iso: string }): JSX.Element {
 
 function AuthError({ status }: { status: 'missing-token' | 'invalid-token' }): JSX.Element {
   const exampleUrl = `${window.location.origin}/?token=YOUR_TOKEN`;
-  const heading = status === 'missing-token' ? 'Token required' : 'Token rejected';
+  const heading =
+    status === 'missing-token' ? 'The token is necessary' : 'The server refused the token';
   const detail =
     status === 'missing-token'
-      ? 'Open the slideshow with a ?token=... query parameter. Find the value in the control panel under Settings → Display token.'
-      : 'The token in the URL was rejected by the server. Check it matches the current value under Settings → Display token (it may have been rotated).';
+      ? 'Open the slideshow with a ?token=... parameter in the address. Find the token in the control panel: Settings → Display token.'
+      : 'The server refused the token in the address. Make sure that it agrees with the token in Settings → Display token. An operator possibly replaced the token.';
   return (
     <div className="flex h-full w-full items-center justify-center bg-black p-8 text-zinc-300">
       <div className="flex max-w-xl flex-col gap-4">
@@ -376,9 +384,9 @@ function ConnectionState({
         <div className="text-sm">{message}</div>
         <div className="text-xs text-zinc-600">
           {conn.state === 'connecting'
-            ? 'connecting…'
+            ? `${CONNECTION_LABEL.connecting}…`
             : conn.state === 'closed'
-              ? 'disconnected (retrying…)'
+              ? `${CONNECTION_LABEL.closed} (the app tries again)`
               : ''}
         </div>
       </div>
@@ -398,7 +406,7 @@ function ConnectionDot({ conn }: { conn: Connection }): JSX.Element {
               : 'h-1.5 w-1.5 rounded-full bg-red-500'
         }
       />
-      {conn.state}
+      {CONNECTION_LABEL[conn.state]}
     </div>
   );
 }

--- a/docs/string-style-guide.md
+++ b/docs/string-style-guide.md
@@ -1,0 +1,112 @@
+# String style guide
+
+Every string that an operator or an audience member reads obeys one of two
+controlled languages:
+
+- **English → ASD-STE100** (Simplified Technical English).
+- **French → le Français Rationalisé du GIFAS.**
+
+The product currently ships English only, so all the strings in the repository
+follow ASD-STE100. The French rules below apply when a translation starts.
+
+## What counts as a string
+
+In scope:
+
+- Labels, hints, buttons, dialogs, empty states, and errors in
+  `apps/web-control` and `apps/web-slideshow`.
+- Electron dialog text in `apps/desktop`.
+- HTTP error bodies in `apps/server/src/routes` — the control panel shows the
+  `error` field to the operator.
+- Console text that the server writes at start and at stop.
+
+Out of scope (do not rewrite):
+
+- Data values that go across the wire: `auto`, `auto-skip-blurry`, `approval`,
+  `pending`, `fade`, `slide-blur`, log levels, and the other enum members.
+- Camera and OBS menu paths (`Network → FTP Transfer Func. → …`). These are
+  quotations of another product. Keep them character for character.
+- Code comments and identifiers.
+- Structured log event names (`bootlog('startServer failed', …)`,
+  `logger.info({ … }, 'app settings updated')`). These are keys for a machine,
+  not sentences for a person.
+
+## ASD-STE100 rules that this repository applies
+
+1. **One word, one meaning.** Each concept has one word. See the glossary.
+2. **Approved words only.** If a word is not in the STE dictionary and it is
+   not a Technical Name, replace it.
+3. **Active voice.** "The server refuses the token", not "the token was
+   rejected".
+4. **Instructions are commands.** "Select Replace", not "you can select
+   Replace".
+5. **One instruction per sentence.** Maximum 20 words in an instruction,
+   maximum 25 words in a description.
+6. **Simple tenses only.** Simple present, simple past, simple future.
+7. **No `-ing` forms** unless the form is part of a Technical Name. This is
+   why a pending button says `Please wait…` and not `Saving…`.
+8. **Keep the articles.** "The token", not "token".
+9. **No contractions.** "cannot", not "can't".
+10. **Maximum three nouns in a noun cluster.**
+11. **No abbreviations** that the STE dictionary does not have, and no
+    abbreviations of ordinary words (`info`, `auto`, `config`).
+
+### Technical Names that this product keeps
+
+PhotoLive, event, photographer, image, thumbnail, caption, slideshow, queue,
+token, slug, log, restart, FTP, OBS, HTTP, WebSocket, CORS, QR code, JPEG,
+PASV, Chromecast, `settings.json`, `.env`.
+
+`restart` is a Technical Name used as a noun only ("Restart necessary",
+"Restart now"). As a verb, write "start the app again".
+
+### Glossary — write this, not that
+
+| Do not write | Write |
+| --- | --- |
+| Loading… / Saving… / Creating… / Deleting… / Signing in… | Please wait… |
+| Sign in / Sign out | Log in / Log out |
+| Create | Make / Add |
+| Activate | Make active |
+| Reveal | Show |
+| Rotate (a token or a password) | Replace |
+| Unarchive | Restore |
+| Curation mode | Selection mode |
+| Info | Details |
+| Latency | Delay |
+| Credentials | The user name and the password |
+| Username | User name |
+| Invalidate | The server refuses … |
+| Failed to X | The system could not X |
+| X is required | X is necessary |
+| Land / fall back / drop / gate (as verbs) | go to / change to / close / approve |
+| Permanently | Completely |
+| auto (as a label) | automatic |
+| unattributed | no photographer |
+
+### Message patterns
+
+- Failure: `The system could not <do the thing>.`
+- Prerequisite: `Make an event active to <do the thing>.`
+- Empty list: `There are no <things>.`
+- Pending control: `Please wait…`
+
+## Le Français Rationalisé du GIFAS
+
+When a French translation starts, it follows the GIFAS rules, which are the
+French counterpart of ASD-STE100:
+
+1. **Lexique contrôlé.** One approved word for each concept, taken from the
+   GIFAS dictionary. No synonyms.
+2. **Voix active** and **indicatif présent**. No passive, no conditional.
+3. **Impératif for the instructions**, one instruction per sentence.
+4. **Maximum 20 words** in an instruction, 25 in a description.
+5. **No participe présent** and no substantive form of a verb where a verb
+   works ("Pour supprimer…", not "Suppression de…").
+6. **Keep the determiners** and no ellipsis of the articles.
+7. **No abbreviations** outside the technical names above.
+8. Keep the technical names of this table in English, because they name
+   the objects of the product interface.
+
+Put the French strings beside the English ones and keep the same message
+patterns, so the two languages stay parallel.

--- a/packages/shared/src/schemas.ts
+++ b/packages/shared/src/schemas.ts
@@ -92,9 +92,9 @@ export const slugSchema = z
   .string()
   .min(1)
   .max(64)
-  .regex(/^[a-z0-9][a-z0-9-]*$/, 'lowercase letters, digits, and hyphens only');
+  .regex(/^[a-z0-9][a-z0-9-]*$/, 'use only lowercase letters, digits and hyphens');
 
-export const colorSchema = z.string().regex(/^#[0-9a-fA-F]{6}$/, 'must be #RRGGBB');
+export const colorSchema = z.string().regex(/^#[0-9a-fA-F]{6}$/, 'use the format #RRGGBB');
 
 export const eventCreateSchema = z.object({
   name: z.string().min(1).max(120),
@@ -150,11 +150,11 @@ export const captionSchema = z.object({
 export const usernameSchema = z
   .string()
   .trim()
-  .min(3, 'at least 3 characters')
+  .min(3, 'use 3 characters minimum')
   .max(64)
-  .regex(/^[a-zA-Z0-9._-]+$/, 'letters, digits, dot, underscore, hyphen only');
+  .regex(/^[a-zA-Z0-9._-]+$/, 'use only letters, digits, a dot, an underscore or a hyphen');
 
-export const passwordSchema = z.string().min(8, 'at least 8 characters').max(256);
+export const passwordSchema = z.string().min(8, 'use 8 characters minimum').max(256);
 
 export const loginSchema = z.object({
   username: usernameSchema,


### PR DESCRIPTION
## What

Every string an operator or an audience member reads is rewritten to follow **ASD-STE100** (Simplified Technical English): approved vocabulary, one word per meaning, active voice, imperative instructions, simple tenses, no `-ing` forms, no contractions, and sentences inside the STE length limits (20 words for an instruction, 25 for a description).

The repo ships **English only** — there is not a single French string in it today (the `en`/`fr` support described in `.github/copilot-instructions.md` belongs to the old v0.1 codebase). So the Français Rationalisé du GIFAS half of the brief had nothing to act on. Rather than drop it, the rules are written down in the new style guide so the first French translation lands under GIFAS instead of ad-hoc.

## Scope

Rewritten:

- `apps/web-control` — every label, hint, button, dialog, empty state, table header, tooltip, and error.
- `apps/web-slideshow` — the token errors, connection states, and the relative-time overlay.
- `apps/desktop` — the six Electron dialogs (data dir, settings load, `.env` import notice, server load, server start, fatal start).
- `apps/server/src/routes` — the HTTP `error` bodies, which the control panel surfaces verbatim in dialogs via `ApiError`.
- `packages/shared/src/schemas.ts` — the Zod validation messages that reach the operator through those same bodies.
- The server's start/stop console output and the reload `reasons[]` that render in the Settings restart banner.

Deliberately untouched:

- Wire values (`auto`, `auto-skip-blurry`, `approval`, `pending`, `fade`, `slide-blur`, log levels). Only their labels changed.
- The quoted Sony A7 IV and OBS menu paths — those are quotations of another product's UI and must stay character for character.
- Structured log event names (`bootlog('startServer failed', …)`) — keys for a machine, not sentences for a person.
- Code comments and identifiers.

## Glossary highlights

| Was | Is |
| --- | --- |
| `Loading…` / `Saving…` / `Creating…` / `Signing in…` | `Please wait…` |
| Sign in / Sign out | Log in / Log out |
| Reveal | Show |
| Rotate (a token or password) | Replace |
| Activate | Make active |
| Unarchive | Restore |
| Curation mode | Selection mode |
| Blur threshold | Sharpness limit |
| Latency | Delay |
| Audit log | Action log |
| Queue tabs: Pending / Skipped / Excluded | To approve / Blurred / Hidden |
| `unattributed` | `no photographer` |
| `Failed to X` | `The system could not X` |

The `-ing` rule is the one with the most visible effect: every pending-state button now reads `Please wait…`, which is also the one-word-one-meaning choice — the same wait means the same thing everywhere.

## New file

`docs/string-style-guide.md` — the rules this PR applied, what is in and out of scope, the full glossary, the four message patterns (`The system could not X.` / `Make an event active to X.` / `There are no Xs.` / `Please wait…`), the list of Technical Names the product keeps, and the GIFAS rules for French. `README.md` links it and picks up the renamed UI elements (it also had a stale `Settings → Authentication` pointer, now `Settings → Display token`).

## Verification

- `pnpm lint`, `pnpm typecheck`, `pnpm test` (16 tests), `pnpm build` — all pass.
- Ran the server against a scratch `settings.json` and checked the rewritten bodies over HTTP: validation messages (`use 3 characters minimum`, `use only lowercase letters, digits and hyphens`), auth (`the setup is already complete`, `the user name or the password is not correct`), conflicts (`this slug is already in use by a different event`), and the 404s (`the server could not find the event` / `… the image` / `… the photographer` / `… this resource`).
- Grepped the built `web-control` and `web-slideshow` bundles to confirm the new strings ship and that `Loading…`, `Saving…`, `Sign in`, `Curation mode`, `unattributed`, `Rotate token`, `Audit log`, and `Restart required` are gone.

No behaviour changes — enum values, routes, and status codes are identical.

---
_Generated by [Claude Code](https://claude.ai/code/session_017rBZLSQZrSzaWqpKAnA4EL)_